### PR TITLE
SystemUI: Expose values for themes.

### DIFF
--- a/packages/SystemUI/res/drawable/volume_dialog_background.xml
+++ b/packages/SystemUI/res/drawable/volume_dialog_background.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright (C) 2015 The CyanogenMod Project
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/system_primary_color" />
+    <corners
+        android:topLeftRadius="0dp"
+        android:topRightRadius="0dp"
+        android:bottomLeftRadius="@dimen/notification_material_rounded_rect_radius"
+        android:bottomRightRadius="@dimen/notification_material_rounded_rect_radius"/>
+</shape>

--- a/packages/SystemUI/res/drawable/zen_mode_panel_background.xml
+++ b/packages/SystemUI/res/drawable/zen_mode_panel_background.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright (C) 2015 The CyanogenMod Project
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/system_secondary_color" />
+    <corners
+        android:topLeftRadius="0dp"
+        android:topRightRadius="0dp"
+        android:bottomLeftRadius="@dimen/zen_mode_panel_radius"
+        android:bottomRightRadius="@dimen/zen_mode_panel_radius"/>
+</shape>

--- a/packages/SystemUI/res/layout/status_bar_expanded_header.xml
+++ b/packages/SystemUI/res/layout/status_bar_expanded_header.xml
@@ -26,7 +26,7 @@
     android:paddingStart="@dimen/notification_side_padding"
     android:paddingEnd="@dimen/notification_side_padding"
     android:baselineAligned="false"
-    android:elevation="4dp"
+    android:elevation="@dimen/status_bar_expanded_header_elevation"
     android:background="@drawable/notification_header_bg"
     android:clickable="true"
     android:focusable="true"

--- a/packages/SystemUI/res/layout/volume_dialog.xml
+++ b/packages/SystemUI/res/layout/volume_dialog.xml
@@ -20,7 +20,7 @@
     android:id="@+id/volume_dialog_bg_container"
     android:layout_marginLeft="@dimen/notification_side_padding"
     android:layout_marginRight="@dimen/notification_side_padding"
-    android:background="@drawable/qs_background_primary"
+    android:background="@drawable/volume_dialog_background"
     android:translationZ="@dimen/volume_panel_z"
     android:layout_marginBottom="@dimen/volume_panel_z">
 

--- a/packages/SystemUI/res/layout/volume_panel.xml
+++ b/packages/SystemUI/res/layout/volume_panel.xml
@@ -24,7 +24,7 @@
         android:id="@+id/slider_panel"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
-        android:background="@color/system_secondary_color"
+        android:background="@color/volume_panel_background_color"
         android:paddingTop="8dp"
         android:paddingLeft="8dp"
         android:paddingRight="8dp"

--- a/packages/SystemUI/res/layout/zen_mode_panel.xml
+++ b/packages/SystemUI/res/layout/zen_mode_panel.xml
@@ -28,7 +28,7 @@
         android:layout_height="wrap_content"
         android:minHeight="12dp"
         android:elevation="4dp"
-        android:background="@drawable/qs_background_secondary" >
+        android:background="@drawable/zen_mode_panel_background" >
 
         <com.android.systemui.volume.SegmentedButtons
             android:id="@+id/zen_buttons"

--- a/packages/SystemUI/res/values/arrays.xml
+++ b/packages/SystemUI/res/values/arrays.xml
@@ -29,7 +29,7 @@
     </array>
     <array name="batterymeter_color_values">
         <item>@*android:color/battery_saver_mode_color</item>
-        <item>#FFFFFFFF</item>
+        <item>@color/batterymeter_base_color</item>
     </array>
     <array name="batterymeter_bolt_points">
         <item>73</item> <item>0</item>

--- a/packages/SystemUI/res/values/cm_colors.xml
+++ b/packages/SystemUI/res/values/cm_colors.xml
@@ -38,4 +38,16 @@
 
     <!-- tint of the Visualizer tile -->
     <color name="visualizer_fill_color">#96FFFFFF</color>
+
+    <!-- Background of the volume panel. See also: volume_dialog_background -->
+    <color name="volume_panel_background_color">@color/system_secondary_color</color>
+
+    <!-- Battery base color -->
+    <color name="batterymeter_base_color">#FFFFFFFF</color>
+
+    <!-- Color for notification icons -->
+    <color name="notification_icon_color">#FFFFFFFF</color>
+
+    <!-- Navigation button ripple color -->
+    <color name="navbutton_ripple_color">#FFFFFFFF</color>
 </resources>

--- a/packages/SystemUI/res/values/cm_dimens.xml
+++ b/packages/SystemUI/res/values/cm_dimens.xml
@@ -16,12 +16,16 @@
 -->
 <resources>
     <dimen name="weather_text_size">12sp</dimen>
-     <dimen name="detail_radio_group_padding_left">16dp</dimen>
-     <dimen name="detail_radio_group_padding">8dp</dimen>
+    <dimen name="detail_radio_group_padding_left">16dp</dimen>
+    <dimen name="detail_radio_group_padding">8dp</dimen>
 
     <!-- Themes: radius of the corners of the notification dropshadow
          See also: notification_material_rounded_rect_radius
     -->
     <dimen name="notification_material_shadow_rounded_rect_radius">0dp</dimen>
+
+    <dimen name="zen_mode_panel_radius">@dimen/notification_material_rounded_rect_radius</dimen>
+
+    <dimen name="status_bar_expanded_header_elevation">4dp</dimen>
 
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/statusbar/BaseStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/BaseStatusBar.java
@@ -731,7 +731,8 @@ public abstract class BaseStatusBar extends SystemUI implements
 
         if (entry.icon != null) {
             if (entry.targetSdk >= Build.VERSION_CODES.LOLLIPOP) {
-                entry.icon.setColorFilter(mContext.getResources().getColor(android.R.color.white));
+                entry.icon.setColorFilter(mContext.getResources().getColor(
+                    R.color.notification_icon_color));
             } else {
                 entry.icon.setColorFilter(null);
             }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/KeyButtonRipple.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/KeyButtonRipple.java
@@ -66,16 +66,19 @@ public class KeyButtonRipple extends Drawable {
     private final HashSet<Animator> mRunningAnimations = new HashSet<>();
     private final ArrayList<Animator> mTmpArray = new ArrayList<>();
 
+    private int mRippleColor;
+
     public KeyButtonRipple(Context ctx, View targetView) {
         mMaxWidth =  ctx.getResources().getDimensionPixelSize(R.dimen.key_button_ripple_max_width);
         mTargetView = targetView;
+        mRippleColor = ctx.getResources().getColor(R.color.navbutton_ripple_color);
     }
 
     private Paint getRipplePaint() {
         if (mRipplePaint == null) {
             mRipplePaint = new Paint();
             mRipplePaint.setAntiAlias(true);
-            mRipplePaint.setColor(0xffffffff);
+            mRipplePaint.setColor(mRippleColor);
         }
         return mRipplePaint;
     }


### PR DESCRIPTION
Allow theming of volume panel separately from status. Allow
status bar icons to be tinted. Expose battery meter base color.
Expose status bar header elevation value. Add themeable ripple
color for navigation button press.

Change-Id: Ie3dbde82692a19927ba6c1da179e5d2f03391f6f